### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   workflow_dispatch:
    


### PR DESCRIPTION
Potential fix for [https://github.com/lendlycagata/ai-demo/security/code-scanning/1](https://github.com/lendlycagata/ai-demo/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out code and scanning it with SonarQube, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, adhering to the principle of least privilege.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`sonarqube`) to limit permissions for that job only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
